### PR TITLE
Add modernization task list and repo recommendations

### DIFF
--- a/docs/issues/high-priority/01-modernize-eclipse-target.md
+++ b/docs/issues/high-priority/01-modernize-eclipse-target.md
@@ -1,0 +1,27 @@
+# Replace Indigo-era Eclipse target with a pinned target platform
+
+## Priority
+High
+
+## Labels
+`modernization`, `eclipse`, `tycho`, `build`
+
+## Background
+The build currently resolves Eclipse dependencies from the Indigo release train. This makes the build depend on very old Eclipse APIs and makes it difficult to validate compatibility with current Eclipse IDE releases.
+
+## Scope
+- Add a checked-in PDE target definition under `releng/target-platform/`.
+- Start with a current Eclipse release repository for exploration, then pin to a dated release train for reproducible CI.
+- Replace HTTP update-site URLs with HTTPS.
+- Keep the target definition minimal: include Platform/UI, JDT Debug, Debug UI, and any other units Mirur directly needs.
+- Document the oldest supported Eclipse release and the latest tested Eclipse release.
+
+## Acceptance criteria
+- `releng/target-platform/mirur.target` exists and is documented.
+- Maven/Tycho uses the checked-in target definition instead of an implicit Indigo p2 repository.
+- The repository documents the selected Eclipse release train and support matrix.
+- The build no longer references `http://download.eclipse.org/releases/indigo/`.
+
+## References
+- Parent POM currently declares the Indigo p2 repository.
+- See `docs/modernization-tasks.md`, section "Move off the Indigo-era Eclipse target".

--- a/docs/issues/high-priority/02-upgrade-tycho.md
+++ b/docs/issues/high-priority/02-upgrade-tycho.md
@@ -1,0 +1,27 @@
+# Upgrade Tycho in staged migrations
+
+## Priority
+High
+
+## Labels
+`modernization`, `tycho`, `maven`, `build`
+
+## Background
+The project is pinned to Tycho 1.1.0, which is old enough that dependency resolution already fails in the current environment. A modern Tycho version is required before reliable CI, target-platform management, and p2 publication can be established.
+
+## Scope
+- Capture the current build failure as a baseline.
+- Upgrade Tycho in staged branches, crossing major versions deliberately rather than making unrelated changes at the same time.
+- Update or replace legacy Tycho plug-in configuration as required by current Tycho documentation.
+- Keep Maven + Tycho as the primary build path.
+- Evaluate Tycho's current support for OSGi tests, API baseline checks, p2 metadata, and source bundles.
+
+## Acceptance criteria
+- The parent POM uses a supported Tycho release.
+- `mvn -B -Dtycho.localArtifacts=ignore clean verify` resolves the target platform and reaches compilation/test phases.
+- Any required migration notes are documented in `docs/development.md` or `docs/modernization-tasks.md`.
+- Tycho upgrade commits do not include unrelated module renames or broad dependency upgrades.
+
+## References
+- Parent POM currently pins `tycho.version` to `1.1.0`.
+- See `docs/modernization-tasks.md`, section "Upgrade Tycho in a staged branch".

--- a/docs/issues/high-priority/03-modernize-java-runtime-and-compiler.md
+++ b/docs/issues/high-priority/03-modernize-java-runtime-and-compiler.md
@@ -1,0 +1,28 @@
+# Define and modernize the Java runtime/compiler baseline
+
+## Priority
+High
+
+## Labels
+`modernization`, `java`, `eclipse`, `build`
+
+## Background
+The build compiles with source/target 8 while using a JDK 11 toolchain, and the bundles declare JavaSE-1.8 or older execution environments. Current Eclipse IDE releases require newer Java runtimes, so Mirur needs an explicit support matrix and compiler strategy.
+
+## Scope
+- Define the minimum supported Eclipse release, runtime JDK, build JDK, and Java language level.
+- Replace `source`/`target` with `release` where compatible with the selected Tycho/Maven setup.
+- Update bundle execution environments consistently across plug-ins and fragments.
+- Review runtime launch arguments and remove or isolate access to JDK internals where possible.
+- Document how to launch the runtime workbench on the supported JDK.
+
+## Acceptance criteria
+- A documented Java/Eclipse support matrix exists.
+- Maven compiler settings and bundle execution environments match the support matrix.
+- Runtime workbench instructions are updated for the selected JDK.
+- Any remaining `--add-exports` or internal JDK access is documented with owner and follow-up tasks.
+
+## References
+- Parent POM currently sets `source` and `target` to `8` and requests a JDK 11 toolchain.
+- Bundles currently declare JavaSE-1.8 or J2SE-1.5 execution environments.
+- See `docs/modernization-tasks.md`, section "Modernize Java runtime and compiler strategy".

--- a/docs/issues/high-priority/04-rework-third-party-dependencies.md
+++ b/docs/issues/high-priority/04-rework-third-party-dependencies.md
@@ -1,0 +1,28 @@
+# Rework third-party dependency and native-library packaging
+
+## Priority
+High
+
+## Labels
+`modernization`, `dependencies`, `osgi`, `jogl`
+
+## Background
+The UI plug-in copies Maven dependencies into `mirur-ui/lib` during the build and embeds JOGL/Glimpse-related jars directly in the bundle classpath. This makes dependency provenance, updates, source bundles, native fragments, and vulnerability scanning harder to manage.
+
+## Scope
+- Inventory all embedded third-party jars, licenses, source jars, and known vulnerabilities.
+- Decide which dependencies should come from the Eclipse target/p2 repositories, which should be wrapped/generated from Maven artifacts, and which should remain embedded.
+- Modernize JOGL, Glimpse, FastUtil, Guava, and MigLayout versions only after target-platform and Tycho upgrades are stable.
+- Validate native fragment packaging for Linux, Windows, macOS x86_64, and macOS aarch64 if supported.
+- Update bundle manifests and `build.properties` to match the chosen packaging strategy.
+
+## Acceptance criteria
+- Dependency inventory exists with versions, licenses, and packaging strategy.
+- Generated/copied dependencies are either removed from source control or clearly documented as committed artifacts.
+- Native fragments have current platform filters and host ranges.
+- Dependency packaging works in a clean checkout and CI environment.
+
+## References
+- `mirur-ui` currently copies dependencies into `lib` during Maven initialization.
+- `mirur-jogl-*` modules unpack platform native artifacts.
+- See `docs/modernization-tasks.md`, section "Rework third-party dependency handling".

--- a/docs/issues/high-priority/05-improve-p2-release-flow.md
+++ b/docs/issues/high-priority/05-improve-p2-release-flow.md
@@ -1,0 +1,28 @@
+# Improve p2 repository publication and release flow
+
+## Priority
+High
+
+## Labels
+`modernization`, `release`, `p2`, `ci`
+
+## Background
+The release flow currently assumes a sibling `mirur-update-site` checkout and includes obsolete Pack200/jarprocessor instructions. Modern releases should produce a repository artifact from CI and publish it without mutating sibling local directories during `mvn install`.
+
+## Scope
+- Make `mirur-repository/target/repository` the canonical build artifact.
+- Remove or gate the copy-to-sibling-update-site behavior so normal installs do not publish locally.
+- Remove obsolete Pack200/jarprocessor release instructions.
+- Add release documentation covering version bumps, tags, p2 artifact upload, signing, checksums, and rollback.
+- Review `category.xml` filters so advertised architectures match supported fragments.
+
+## Acceptance criteria
+- `mvn clean verify` produces a p2 repository artifact without requiring a sibling checkout.
+- Release publication is documented and suitable for CI automation.
+- Pack200 instructions are removed or clearly marked obsolete.
+- `category.xml` architecture/OS filters match the supported bundles/fragments.
+
+## References
+- `mirur-repository` currently mirrors output to `../../mirur-update-site/update-site/` during install.
+- README release steps reference a sibling checkout and jarprocessor/Pack200 flow.
+- See `docs/modernization-tasks.md`, section "Improve p2 repository and release flow".

--- a/docs/issues/high-priority/06-add-automated-test-structure.md
+++ b/docs/issues/high-priority/06-add-automated-test-structure.md
@@ -1,0 +1,27 @@
+# Add automated test structure for core, OSGi, and UI behavior
+
+## Priority
+High
+
+## Labels
+`modernization`, `tests`, `quality`, `eclipse`
+
+## Background
+The repository has some test sources and a manual sample workspace, but it does not yet have a clearly documented automated test strategy for core array logic, OSGi integration, or Eclipse UI behavior.
+
+## Scope
+- Separate plain JVM unit tests for array visitors, conversion, sorting, statistics, finite-value handling, and CSV export.
+- Add Tycho/OSGi plug-in tests for extension wiring and Eclipse service integration.
+- Evaluate SWTBot or a lighter runtime-workbench smoke test for views, preferences, and debug UI integration.
+- Move or document `test-workspace` as manual examples if it is not an automated fixture.
+- Ensure tests run headlessly in CI where feasible.
+
+## Acceptance criteria
+- Test strategy is documented.
+- At least one core JVM test suite runs under Maven.
+- OSGi/UI test approach is chosen and documented, even if UI tests are initially smoke-only.
+- Manual examples are either moved under `examples/` or documented in place.
+
+## References
+- Existing `test-workspace` appears to contain manual/sample Java projects.
+- See `docs/modernization-tasks.md`, section "Add automated test structure".

--- a/docs/issues/high-priority/07-establish-ci-and-repository-hygiene.md
+++ b/docs/issues/high-priority/07-establish-ci-and-repository-hygiene.md
@@ -1,0 +1,28 @@
+# Establish CI and repository hygiene for modernization work
+
+## Priority
+High
+
+## Labels
+`modernization`, `ci`, `developer-experience`, `maintenance`
+
+## Background
+Modernization work needs repeatable tooling so build failures are visible and future dependency/target-platform updates are safer. The repository should define Maven, CI, generated-file handling, formatting, and agent/developer operating instructions.
+
+## Scope
+- Add Maven Wrapper and pin the Maven version used by CI.
+- Add CI that runs a full Tycho build, license checks, and dependency/license reports.
+- Add optional Linux UI smoke tests under xvfb if/when UI tests exist.
+- Add or refresh `.gitignore` for generated outputs, copied libraries, native artifacts, IDE metadata, and test output.
+- Add formatter/import-order configuration, preferably compatible with Eclipse JDT.
+- Add root `AGENTS.md` so coding agents know build commands, metadata files, and project guardrails.
+- Configure dependency update automation such as Renovate after the target-platform strategy is stable.
+
+## Acceptance criteria
+- CI runs on pull requests and main-branch pushes.
+- Developers can run the same build locally through `./mvnw`.
+- Generated artifacts are ignored or explicitly documented if committed.
+- `AGENTS.md` exists with project-specific build and Eclipse plug-in instructions.
+
+## References
+- See `docs/modernization-tasks.md`, sections "Establish CI and repository hygiene" and "Suggested `AGENTS.md` content".

--- a/docs/issues/high-priority/README.md
+++ b/docs/issues/high-priority/README.md
@@ -1,0 +1,27 @@
+# High-priority modernization issue drafts
+
+These files are ready-to-copy issue bodies for the high-priority tasks identified in `docs/modernization-tasks.md`.
+
+## Issue drafts
+
+1. [Replace Indigo-era Eclipse target with a pinned target platform](01-modernize-eclipse-target.md)
+2. [Upgrade Tycho in staged migrations](02-upgrade-tycho.md)
+3. [Define and modernize the Java runtime/compiler baseline](03-modernize-java-runtime-and-compiler.md)
+4. [Rework third-party dependency and native-library packaging](04-rework-third-party-dependencies.md)
+5. [Improve p2 repository publication and release flow](05-improve-p2-release-flow.md)
+6. [Add automated test structure for core, OSGi, and UI behavior](06-add-automated-test-structure.md)
+7. [Establish CI and repository hygiene for modernization work](07-establish-ci-and-repository-hygiene.md)
+
+## Suggested `gh` commands
+
+If the repository is available through the GitHub CLI, create the issues with commands like:
+
+```sh
+gh issue create --title "Replace Indigo-era Eclipse target with a pinned target platform" --label modernization,eclipse,tycho,build --body-file docs/issues/high-priority/01-modernize-eclipse-target.md
+gh issue create --title "Upgrade Tycho in staged migrations" --label modernization,tycho,maven,build --body-file docs/issues/high-priority/02-upgrade-tycho.md
+gh issue create --title "Define and modernize the Java runtime/compiler baseline" --label modernization,java,eclipse,build --body-file docs/issues/high-priority/03-modernize-java-runtime-and-compiler.md
+gh issue create --title "Rework third-party dependency and native-library packaging" --label modernization,dependencies,osgi,jogl --body-file docs/issues/high-priority/04-rework-third-party-dependencies.md
+gh issue create --title "Improve p2 repository publication and release flow" --label modernization,release,p2,ci --body-file docs/issues/high-priority/05-improve-p2-release-flow.md
+gh issue create --title "Add automated test structure for core, OSGi, and UI behavior" --label modernization,tests,quality,eclipse --body-file docs/issues/high-priority/06-add-automated-test-structure.md
+gh issue create --title "Establish CI and repository hygiene for modernization work" --label modernization,ci,developer-experience,maintenance --body-file docs/issues/high-priority/07-establish-ci-and-repository-hygiene.md
+```

--- a/docs/modernization-tasks.md
+++ b/docs/modernization-tasks.md
@@ -176,6 +176,8 @@ Mirur is an Eclipse plug-in built with Maven and Tycho. The main UI bundle is `m
 
 ## Issue backlog
 
+High-priority issue drafts for the seven sections above are available under `docs/issues/high-priority/` so they can be copied directly into GitHub issues or used by another issue tracker.
+
 ### Build and dependency issues
 
 - [ ] Replace Indigo p2 target with a pinned `.target` file.

--- a/docs/modernization-tasks.md
+++ b/docs/modernization-tasks.md
@@ -1,0 +1,229 @@
+# Modernization and Upgrade Task List
+
+This document records recommended work for modernizing Mirur while keeping the current change set limited to suggestions only.
+
+## Current repository snapshot
+
+Mirur is a Maven/Tycho-built Eclipse plug-in repository with these main modules:
+
+- `mirur-agent`: Java agent bundle used by the debugger integration.
+- `mirur-ui`: main Eclipse UI plug-in, views, preferences, array copying, and bundled visualization dependencies.
+- `mirur-feature`: Eclipse feature wrapping the plug-ins/fragments.
+- `mirur-repository`: p2 update-site repository module.
+- `mirur-jogl-parent` plus `mirur-jogl-linux64`, `mirur-jogl-win64`, and `mirur-jogl-osx`: platform native fragments for JOGL.
+- `test-workspace`: manual/sample workspace content rather than automated test fixtures.
+
+## Highest-priority upgrade tasks
+
+### 1. Move off the Indigo-era Eclipse target
+
+- Replace the current `http://download.eclipse.org/releases/indigo/` p2 target with an explicit `.target` file checked into the repository, likely under `releng/target-platform/`.
+- Start with a current Eclipse simultaneous-release repository, for example `https://download.eclipse.org/releases/latest/` for exploratory work, then pin to a dated release train for reproducible CI.
+- Use HTTPS for all update-site URLs.
+- Keep the target definition small: include the Eclipse Platform/JDT/Debug/UI units that Mirur really needs instead of making an entire release train the implicit target platform.
+- Add a task to test both "oldest supported Eclipse" and "latest Eclipse" before declaring compatibility.
+
+Rationale: the parent POM currently uses an Indigo p2 repository and old bundle lower bounds such as Eclipse UI/JDT Debug 3.7.x. A modern target platform will surface API removals, split packages, JPMS access issues, and native-library behavior changes early.
+
+### 2. Upgrade Tycho in a staged branch
+
+- Stay with Maven + Tycho as the primary build. Tycho remains the Eclipse project's Maven-centric build system for Eclipse plug-ins, OSGi bundles, features, p2 repositories, RCP applications, and BND workspaces.
+- Upgrade in stages rather than jumping directly from Tycho `1.1.0` to the latest line:
+  1. Establish a reproducible baseline with the current build.
+  2. Upgrade to a newer Tycho 2.x/3.x/4.x line only as needed to cross breaking changes.
+  3. Then evaluate Tycho 5.x, which is current in 2026.
+- Replace legacy Tycho plug-in names/configuration where the current Tycho documentation requires it.
+- Add Tycho's test support for OSGi/UI tests and consider Tycho API Tools/Baseline checks once public API boundaries are defined.
+- Investigate Tycho's pomless/structured layout only after the normal Maven build is healthy. Do not make this the first migration because this repository already has a small explicit multi-module Maven structure.
+
+External references checked on 2026-05-17:
+
+- Tycho official docs describe Tycho as Maven tooling for Eclipse plug-ins, OSGi bundles, features, update sites/p2 repositories, RCP applications, and BND workspaces: https://tycho.eclipseprojects.io/doc/latest/
+- Eclipse project metadata lists Tycho `5.0.2` as released on 2026-01-24: https://projects.eclipse.org/projects/technology.tycho/governance
+- Tycho target-platform docs recommend p2 repositories with `<layout>p2</layout>` and support `.target` files for finer control: https://tycho.eclipseprojects.io/doc/main/TargetPlatform.html
+- Tycho build-properties docs note Tycho supports only a subset of PDE `build.properties` keys and suggests Maven/toolchain alternatives for some legacy keys: https://tycho.eclipseprojects.io/doc/latest/BuildProperties.html
+
+### 3. Modernize Java runtime and compiler strategy
+
+- Decide and document the support matrix:
+  - Minimum runtime Eclipse/JDK combination.
+  - JDK used to run Maven/Tycho in CI.
+  - Java language level used to compile Mirur bundles.
+- Move from source/target `8` and JavaSE-1.8 bundle execution environments to a supported baseline such as Java 17 if the selected Eclipse release train requires it.
+- Prefer `maven-compiler-plugin` `release` over separate `source`/`target` where compatible with the selected Tycho version.
+- Revisit JVM arguments in `README.md`; the current `--add-exports` requirements indicate deep reflection/internal API access that should be minimized or isolated.
+
+### 4. Rework third-party dependency handling
+
+- Inventory all embedded libraries in `mirur-ui/lib` and confirm licenses, source availability, and CVEs.
+- Replace copying Maven dependencies into `mirur-ui/lib` during `initialize` with a more reproducible approach:
+  - Prefer target-platform/p2-provided bundles when available.
+  - For plain Maven jars, use Tycho's current `pomDependencies` or generated OSGi bundles if appropriate.
+  - Keep native fragments for platform-specific JOGL artifacts only if still required.
+- Update JOGL/Glimpse/FastUtil/Guava/MigLayout versions after checking compatibility with current Eclipse SWT/OpenGL behavior.
+- Verify whether the separate JOGL native fragments still need `J2SE-1.5` bundle execution environments and whether macOS should support both x86_64 and aarch64.
+
+### 5. Improve p2 repository and release flow
+
+- Stop writing release output to a sibling checkout such as `../mirur-update-site/update-site/` during a normal `mvn install`.
+- Make repository output a build artifact from `mirur-repository/target/repository` and publish it from CI.
+- Remove or replace Pack200/jarprocessor instructions; Pack200 is obsolete in modern Java/Eclipse distributions.
+- Add signing strategy for jars/update-site metadata if distributing publicly.
+- Update `category.xml` so architecture filters match actual supported fragments; it currently advertises `x86` even though fragments are x86_64-only.
+- Add release checklist tasks for version bumping, changelog generation, tag creation, GitHub release/upload, and update-site publication.
+
+### 6. Add automated test structure
+
+- Split tests into:
+  - Plain JVM unit tests for `mirur.core` array visitors and data conversion.
+  - OSGi/Tycho plug-in tests for extension wiring and Eclipse services.
+  - SWTBot or Eclipse UI smoke tests for views/preferences if maintainers want UI coverage.
+- Move manual sample projects under a clearly named `examples/` or `test-workspace/README.md` and document how they are used.
+- Add regression tests for primitive arrays, boxed arrays, lists, jagged arrays, complex/interleaved arrays, sorting, min/max, finite-value handling, CSV export, and tooltip/selection behavior.
+
+### 7. Establish CI and repository hygiene
+
+- Add Maven Wrapper (`mvnw`, `.mvn/wrapper`) and commit the Maven version used by CI.
+- Add GitHub Actions or another CI workflow that runs at least:
+  - `./mvnw -B -Dtycho.localArtifacts=ignore clean verify`
+  - license check
+  - dependency vulnerability/license reporting
+  - optional UI smoke test on Linux with xvfb
+- Add `.gitignore` entries for generated `target/`, copied `lib/` jars, native files unpacked into fragment projects, IDE metadata, and test output if missing.
+- Add formatting/import rules. For Java, consider Eclipse JDT formatter configuration because this is an Eclipse plug-in project.
+- Add dependency update automation such as Renovate, configured carefully for Tycho/p2 and Maven dependency updates.
+
+## Recommended repository structure changes
+
+A conservative Maven/Tycho-friendly layout could be:
+
+```text
+/
+  AGENTS.md                         # Coding-agent operating instructions
+  README.md                         # User/developer quick start
+  docs/
+    modernization-tasks.md          # This task list
+    architecture.md                 # Bundle responsibilities and extension points
+    release.md                      # Versioning, p2 publication, signing
+    development.md                  # IDE import, target platform, run/debug configs
+  releng/
+    target-platform/
+      mirur.target                  # Pinned Eclipse target definition
+    ci/
+      README.md                     # CI/test matrix notes, if needed
+  examples/
+    simple/                         # Rename/move current manual test workspace projects
+  mirur-agent/
+  mirur-ui/
+  mirur-feature/
+  mirur-repository/
+  mirur-jogl-parent/
+  mirur-jogl-linux64/
+  mirur-jogl-win64/
+  mirur-jogl-osx/
+```
+
+Keep module renames optional. If renaming modules, prefer Eclipse/OSGi-style names for consistency:
+
+- `mirur-ui` -> `mirur.mirur-ui` or `plugins/mirur.mirur-ui`
+- `mirur-agent` -> `mirur.jdk-agent` or `plugins/mirur.jdk-agent`
+- `mirur-feature` -> `features/mirur.feature`
+- `mirur-repository` -> `releng/mirur.repository`
+- native fragments -> `fragments/mirur.jogl.*`
+
+Do not combine renames with the Tycho upgrade; do them after the build is green so any resolver breakage is attributable.
+
+## Suggested `AGENTS.md` content
+
+Add a root-level `AGENTS.md` so Codex, Claude, and other coding agents can work safely. Suggested sections:
+
+```markdown
+# AGENTS.md
+
+## Project overview
+Mirur is an Eclipse plug-in built with Maven and Tycho. The main UI bundle is `mirur-ui`; the Java agent bundle is `mirur-agent`; `mirur-feature` and `mirur-repository` package the installable feature and p2 repository; `mirur-jogl-*` projects provide JOGL native fragments.
+
+## Ground rules
+- Prefer Maven/Tycho metadata (`pom.xml`, `META-INF/MANIFEST.MF`, `feature.xml`, `category.xml`, `build.properties`) over IDE-only metadata.
+- Do not edit generated `target/` outputs or copied dependency jars in `mirur-ui/lib` unless the task is specifically about dependency packaging.
+- Keep bundle IDs, artifact IDs, and feature IDs aligned when changing versions.
+- Avoid broad dependency updates without running a full Tycho build.
+- Do not add try/catch wrappers around imports.
+
+## Build and test commands
+- `mvn -B -Dtycho.localArtifacts=ignore clean verify`
+- `mvn -B -pl mirur-ui -am test`
+- `mvn -B license:check`
+
+## Eclipse plug-in notes
+- Check `META-INF/MANIFEST.MF` when adding package imports or bundle dependencies.
+- Check `build.properties` when adding resources that must be shipped in the bundle.
+- Check `plugin.xml` when changing views, preference pages, or debug UI integration.
+- Check `feature.xml` and `category.xml` when changing installable units.
+
+## Modernization priorities
+- Keep Maven + Tycho unless explicitly asked to evaluate another build system.
+- Prefer a checked-in `.target` definition under `releng/target-platform`.
+- Prefer CI-published p2 repositories over writing into a sibling update-site checkout.
+```
+
+## Eclipse plug-in build-system recommendation
+
+- Recommended default: continue with Maven + Tycho. This is the least disruptive and is still the standard headless build path for Maven-based Eclipse plug-in, feature, and p2 repository builds.
+- Recommended enhancement: add a checked-in PDE target file and use Tycho to resolve against it. This improves reproducibility and helps developers import the same target into Eclipse IDE.
+- Optional future evaluation: BND workspace layout/pomless Tycho. This can reduce POM boilerplate for OSGi-heavy projects, but it is not the best first step here because Mirur already uses Tycho packaging types and only has a handful of modules.
+- Avoid as a first migration: Gradle-only rebuild. Gradle can build OSGi artifacts, but Eclipse plug-in ecosystems still commonly rely on PDE metadata and Tycho for p2/update-site workflows. A Gradle migration would add risk without solving the current known blockers.
+
+## Issue backlog
+
+### Build and dependency issues
+
+- [ ] Replace Indigo p2 target with a pinned `.target` file.
+- [ ] Upgrade Tycho from `1.1.0` through a staged migration to a supported modern release.
+- [ ] Replace HTTP URLs in build metadata with HTTPS.
+- [ ] Remove Pack200/jarprocessor release steps.
+- [ ] Stop publishing to a sibling checkout during `install`.
+- [ ] Review and modernize Maven plug-in versions.
+- [ ] Add Maven Wrapper.
+- [ ] Add CI with JDK/Eclipse/Tycho matrix.
+- [ ] Add dependency vulnerability and license reports.
+- [ ] Decide whether copied jars in `mirur-ui/lib` are generated or committed; enforce with `.gitignore` and documentation.
+
+### Eclipse/OSGi issues
+
+- [ ] Update `Bundle-RequiredExecutionEnvironment` values.
+- [ ] Review `Require-Bundle` version ranges and replace with `Import-Package` where appropriate.
+- [ ] Add/validate source bundles for update-site consumers.
+- [ ] Validate native fragment host ranges and platform filters.
+- [ ] Add macOS aarch64 support if JOGL/Glimpse support it.
+- [ ] Check `plugin.xml` extension points against current Eclipse Platform/JDT Debug APIs.
+
+### Code issues
+
+- [ ] Remove or isolate use of JDK internals that require `--add-exports`.
+- [ ] Audit JDI array-copy behavior on modern JDKs.
+- [ ] Improve error handling and logging around debug-target communication and native/OpenGL initialization.
+- [ ] Add tests for all array visitors and plot data transformations.
+- [ ] Review high-DPI/font-scaling behavior.
+- [ ] Review linear/nonlinear axis labeling bugs.
+- [ ] Add copy-to-clipboard support or close the existing TODO.
+
+### Documentation issues
+
+- [ ] Expand `README.md` with current build prerequisites, target-platform setup, and troubleshooting.
+- [ ] Add `docs/development.md` for importing into Eclipse and launching a runtime workbench.
+- [ ] Add `docs/release.md` for versioning, signing, p2 publishing, and rollback.
+- [ ] Add root `AGENTS.md` for coding agents.
+- [ ] Move or explain `test-workspace` examples.
+- [ ] Replace dead/legacy project URLs if `mirur.io` is no longer maintained.
+
+## Suggested first implementation sequence
+
+1. Add `AGENTS.md`, Maven Wrapper, `.gitignore`, and CI skeleton.
+2. Capture current build failures and document prerequisites.
+3. Add `releng/target-platform/mirur.target` pinned to a current Eclipse release.
+4. Upgrade Tycho until `mvn clean verify` resolves and packages the p2 repository.
+5. Update Java baseline and remove or minimize `--add-exports` requirements.
+6. Rework dependency packaging and native fragments.
+7. Add automated unit/plug-in tests.
+8. Update release flow and publish artifacts from CI.


### PR DESCRIPTION
### Motivation
- Capture a prioritized modernization plan to move the project off an Indigo-era target, stage Tycho upgrades, and modernize the Java/OSGi runtime strategy. 
- Provide a checklist and recommended repository/layout changes so maintainers and automation (CI/coding agents) can perform upgrades in a reproducible, low-risk sequence. 
- Encourage safer handling of third-party dependencies, p2/release flow, and automated testing to make future changes traceable and CI-friendly.

### Description
- Add `docs/modernization-tasks.md`, a comprehensive task list that documents the repository snapshot, high-priority upgrade items (target platform, staged Tycho upgrade, Java baseline), dependency packaging and native fragment guidance, p2/release flow, CI and hygiene recommendations, and a suggested implementation sequence. 
- Recommend repository structure changes (checked-in `releng/target-platform`, `docs/`, `examples/`, and a root `AGENTS.md`) and provide suggested `AGENTS.md` content so Codex/Claude-style agents can operate safely. 
- Keep Maven + Tycho as the recommended build path while calling out staged Tycho upgrades and explicit target definitions, and warn against an immediate Gradle migration. 
- Provide an actionable issue backlog (build, OSGi, code, and documentation items) and concrete first steps (add Maven Wrapper, CI skeleton, pinned `.target`, etc.).

### Testing
- Ran `git diff --check`, which succeeded with no whitespace or index issues. 
- Ran `mvn -B -DskipTests validate`, which failed to resolve the legacy Tycho build extension (`org.eclipse.tycho:tycho-maven-plugin:1.1.0`); this failure is expected and is captured as a modernization target in the new documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1ed52c38832293fe0ed4d59087f9)