### PR TITLE
Publish p2 repository from build artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,28 +25,20 @@ Mirur resolves Eclipse plug-in APIs through the pinned target definition in
 Eclipse release train, supported Eclipse matrix, and target-platform update
 process.
 
-The `gh-pages` branch contains the website and the update-site folder for
-releases. Both the development branch (e.g. `master`) and `gh-pages` need to be
-checked out alongside each other build. The build assumes `gh-pages` is checked
-out in a folder called `mirur-update-site` at the same level as the main code.
-For example, `mirur` and `mirur-update-site` are sibling folders.
+Build and verify the project with Maven:
 
 ```
-cd mirur
-mvn versions:set -DnewVersion=X-SNAPSHOT && mvn tycho-versions:set-version -DnewVersion=X.qualifier
-git commit -a -m "Version to X" && git tag X
-mvn clean install
+mvn clean verify
 ```
 
-Now the new build is in `../mirur-update-site/update-site/`
+The p2 update-site repository is produced at
+`mirur-repository/target/repository`. A normal `mvn install` or `mvn verify` does
+not copy that repository into a sibling checkout. Release automation should
+archive and publish the repository artifact from that target directory.
 
-```
-cd ../mirur-update-site/update-site/
-unzip content.jar && unzip artifacts.jar
-# Note this does not work on recent versions of the jarprocessor as of 2023
-java -jar ../eclipse/plugins/org.eclipse.equinox.p2.jarprocessor_1.*.jar \
-  -processAll -pack -verbose -outputDir plugins plugins/mirur.mirur-ui_*
-```
+See `docs/release.md` for the release checklist, version/tag steps, signing and
+checksum guidance, rollback procedure, and how to keep the existing public p2
+update-site URL stable for current installs.
 
 ## Testing
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,73 @@
+# Release process
+
+This project publishes Mirur as an Eclipse p2 update site. The canonical build
+output is `mirur-repository/target/repository`; release automation should upload
+that directory instead of relying on a sibling checkout next to the source tree.
+
+## Update site compatibility
+
+Keep the public p2 update-site URL stable for existing installs. Existing users
+can continue to point Eclipse at the same update-site link as long as the release
+job publishes the contents of `mirur-repository/target/repository` to the same
+`update-site/` path that is currently served by the `gh-pages` site.
+
+Changing the URL is only required if the hosting location, branch, or published
+path changes. If that ever happens, publish a redirect or a final repository at
+the old URL that includes instructions for the new location before removing the
+old site.
+
+## Release checklist
+
+1. Confirm the support matrix in `releng/target-platform/mirur.target`, the
+   Tycho environments in the parent `pom.xml`, and `mirur-repository/category.xml`.
+2. Choose the release version, then update Maven and Tycho/PDE metadata:
+
+   ```sh
+   mvn versions:set -DnewVersion=X.Y.Z-SNAPSHOT
+   mvn tycho-versions:set-version -DnewVersion=X.Y.Z.qualifier
+   ```
+
+   For a final release, use the release version in Maven metadata and the matching
+   `.qualifier` value in Eclipse metadata before tagging.
+3. Run the full verification build:
+
+   ```sh
+   mvn clean verify
+   ```
+
+4. Inspect `mirur-repository/target/repository` and archive it as the CI release
+   artifact. The repository should contain p2 metadata (`content.jar` or
+   `content.xml`, `artifacts.jar` or `artifacts.xml`) plus `features/` and
+   `plugins/` entries.
+5. Sign jars and repository metadata according to the project's signing policy.
+   The historical Pack200/jarprocessor workflow is obsolete and must not be used
+   for modern Java and Eclipse releases.
+6. Generate checksums for the archived p2 repository artifact, for example:
+
+   ```sh
+   (cd mirur-repository/target && zip -r mirur-p2-repository-X.Y.Z.zip repository)
+   shasum -a 256 mirur-repository/target/mirur-p2-repository-X.Y.Z.zip
+   ```
+
+7. Create and push the release tag after verification succeeds:
+
+   ```sh
+   git tag X.Y.Z
+   git push origin X.Y.Z
+   ```
+
+8. Publish the repository artifact to the existing public update-site path. For
+   the current GitHub Pages setup, copy the contents of
+   `mirur-repository/target/repository/` into the `update-site/` directory on the
+   publishing branch, then deploy that branch from CI.
+9. Smoke-test installation from the public update-site URL in a clean Eclipse
+   profile.
+10. Bump back to the next `-SNAPSHOT`/`.qualifier` development version on the
+    development branch.
+
+## Rollback
+
+If a published p2 repository is bad, restore the previous known-good contents of
+the public `update-site/` path and redeploy it. Keep the release artifact and its
+checksums attached to the release for auditability, but mark the GitHub release or
+tag as withdrawn if consumers should not install it.

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,12 +23,13 @@ old site.
 2. Choose the release version, then update Maven and Tycho/PDE metadata:
 
    ```sh
-   mvn versions:set -DnewVersion=X.Y.Z-SNAPSHOT
+   mvn versions:set -DnewVersion=X.Y.Z
    mvn tycho-versions:set-version -DnewVersion=X.Y.Z.qualifier
    ```
 
-   For a final release, use the release version in Maven metadata and the matching
-   `.qualifier` value in Eclipse metadata before tagging.
+   Use the final release version (without `-SNAPSHOT`) in Maven metadata and the
+   matching `.qualifier` value in Eclipse metadata before verifying and tagging;
+   reserve the next `-SNAPSHOT` Maven version for the post-release bump.
 3. Run the full verification build:
 
    ```sh

--- a/mirur-repository/category.xml
+++ b/mirur-repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/mirur.feature_2.2.1.qualifier.jar" id="mirur.feature" version="2.2.1.qualifier" os="linux,macosx,win32" arch="x86,x86_64">
+   <feature url="features/mirur.feature_2.2.1.qualifier.jar" id="mirur.feature" version="2.2.1.qualifier" os="linux,macosx,win32" arch="x86_64">
       <category name="mirur.category"/>
    </feature>
    <category-def name="mirur.category" label="Mirur Debugging Tool">

--- a/mirur-repository/pom.xml
+++ b/mirur-repository/pom.xml
@@ -22,31 +22,6 @@
                     <createArtifactRepository>true</createArtifactRepository>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.eclipse.tycho.extras</groupId>
-                <artifactId>tycho-p2-extras-plugin</artifactId>
-                <version>${tycho.version}</version>
-                <executions>
-                    <execution>
-                        <id>copy-to-update-site</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>mirror</goal>
-                        </goals>
-                        <configuration>
-                            <source>
-                                <repository>
-                                    <url>${project.baseUri}/target/repository</url>
-                                </repository>
-                            </source>
-                            <includePacked>true</includePacked>
-                            <append>true</append>
-                            <compress>false</compress>
-                            <destination>${basedir}/../../mirur-update-site/update-site/</destination>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
### Motivation
- Modernize the p2 update-site publication so CI produces and publishes a canonical repository artifact instead of mutating sibling checkouts during a normal build. 
- Remove reliance on obsolete Pack200/jarprocessor steps and clarify release/rollback/signing responsibilities for modern Java/Eclipse releases. 
- Ensure advertised category metadata matches the actual supported native fragments/architectures.

### Description
- Remove the `install`-phase mirror execution (`tycho-p2-extras`/`mirror`) from `mirur-repository/pom.xml` so `mirur-repository/target/repository` is the canonical p2 artifact. 
- Update `README.md` to recommend `mvn clean verify` and document the canonical repository output at `mirur-repository/target/repository`. 
- Add `docs/release.md` with a release checklist covering version/tag steps, artifact inspection, signing guidance (explicitly marking Pack200/jarprocessor as obsolete), checksum generation, CI publication to the existing `update-site/` path, smoke tests, and rollback instructions. 
- Adjust `mirur-repository/category.xml` to advertise `arch="x86_64"` only so category filters align with the x86_64-only native fragments.

### Testing
- Ran `git diff --check` with no whitespace errors reported. 
- Verified the modified XML files parse successfully using `python3`/`xml.etree.ElementTree` on `mirur-repository/pom.xml` and `mirur-repository/category.xml`. 
- Executed `mvn clean verify`, which started the reactor but the build failed before the repository module due to upstream dependency/target-platform resolution errors (failed to read artifact descriptor for `org.apache.commons:commons-lang3:3.8.1` and a missing `mirur-target-platform` target artifact in this environment). 
- Attempted `mvn verify -rf :mirur.jogl-parent -e` to reproduce and debug the failure, and observed Tycho target artifact resolution errors caused by the interrupted reactor and absent published target artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6d3028b48322b9cdd3e7e4e1a922)