### PR TITLE
Add Eclipse workbench smoke tests for Mirur UI

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -23,7 +23,27 @@ compiles its Java sources for Java 21 (`<release>21</release>`).
 mvn -B -Dtycho.localArtifacts=ignore clean verify
 ```
 
-## Java and Eclipse support matrix
+## Automated Eclipse smoke tests
+
+The `mirur-ui.tests` module is a Tycho `eclipse-test-plugin` that launches the
+Eclipse IDE workbench with the Mirur UI bundle installed. Its smoke tests start
+the bundle, verify the registered workbench extensions for Mirur views,
+preferences, and debug detail panes, and instantiate the lightweight Statistics
+view. The test workspace is created under `mirur-ui.tests/target/workspaces/` so
+the checked-in `test-workspace/` directory can remain a manual/sample workspace
+for debugger scenarios.
+
+Run just the plug-in smoke tests after the upstream modules have been built with:
+
+```bash
+mvn -B -Dtycho.localArtifacts=ignore -pl mirur-agent,mirur-ui,mirur-ui.tests -am verify
+```
+
+On Linux CI agents, run this command under `xvfb-run` when no display server is
+available because the tests intentionally exercise the Eclipse workbench UI
+harness.
+
+## Eclipse compatibility matrix
 
 | Compatibility item | Supported baseline | Notes |
 | --- | --- | --- |

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,7 +36,7 @@ for debugger scenarios.
 Run just the plug-in smoke tests after the upstream modules have been built with:
 
 ```bash
-mvn -B -Dtycho.localArtifacts=ignore -pl mirur-agent,mirur-ui,mirur-ui.tests -am verify
+mvn -B -Dtycho.localArtifacts=ignore -pl mirur-agent,mirur-ui,mirur-ui.tests,releng/target-platform -am verify
 ```
 
 On Linux CI agents, run this command under `xvfb-run` when no display server is

--- a/mirur-ui.tests/META-INF/MANIFEST.MF
+++ b/mirur-ui.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Mirur UI Smoke Tests
+Bundle-SymbolicName: mirur.mirur-ui.tests
+Bundle-Version: 2.2.1.qualifier
+Bundle-Vendor: Mirur
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.ui,
+ org.junit,
+ mirur.mirur-ui

--- a/mirur-ui.tests/build.properties
+++ b/mirur-ui.tests/build.properties
@@ -1,0 +1,4 @@
+output.. = target/classes/
+bin.includes = META-INF/,
+               .
+source.. = src/test/java/

--- a/mirur-ui.tests/pom.xml
+++ b/mirur-ui.tests/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>mirur</groupId>
+        <artifactId>mirur-parent</artifactId>
+        <version>2.2.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mirur.mirur-ui.tests</artifactId>
+    <packaging>eclipse-test-plugin</packaging>
+    <name>mirur-ui tests</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho.version}</version>
+                <configuration>
+                    <useUIHarness>true</useUIHarness>
+                    <useUIThread>true</useUIThread>
+                    <application>org.eclipse.ui.ide.workbench</application>
+                    <appArgLine>-data ${project.build.directory}/workspaces/smoke --launcher.suppressErrors</appArgLine>
+                    <argLine>-Djava.awt.headless=true</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mirur-ui.tests/src/test/java/mirur/plugin/PluginSmokeTest.java
+++ b/mirur-ui.tests/src/test/java/mirur/plugin/PluginSmokeTest.java
@@ -1,0 +1,79 @@
+package mirur.plugin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+public class PluginSmokeTest {
+    private static final String PLUGIN_ID = "mirur.mirur-ui";
+    private static final String STATISTICS_VIEW_ID = "mirur.views.Statistics";
+    private static final String STATISTICS_VIEW_CLASS = "mirur.plugin.statsview.ArrayStatsView";
+    private static final String PREFERENCES_PAGE_ID = "mirur.preferences.main";
+
+    @Test
+    public void startsMirurBundleInsideWorkbenchRuntime() throws Exception {
+        Bundle bundle = Platform.getBundle(PLUGIN_ID);
+
+        assertNotNull("Mirur UI bundle should be installed in the test runtime", bundle);
+        bundle.start(Bundle.START_TRANSIENT);
+
+        assertEquals("Mirur UI bundle should start successfully", Bundle.ACTIVE, bundle.getState());
+        assertTrue("Tycho should launch the Eclipse workbench for these smoke tests", PlatformUI.isWorkbenchRunning());
+    }
+
+    @Test
+    public void registersExpectedWorkbenchExtensions() {
+        IExtensionRegistry registry = Platform.getExtensionRegistry();
+
+        assertExtensionRegistered(registry, "org.eclipse.ui.views", "id", "mirur.views.Painter");
+        assertExtensionRegistered(registry, "org.eclipse.ui.views", "id", STATISTICS_VIEW_ID);
+        assertExtensionRegistered(registry, "org.eclipse.ui.preferencePages", "id", PREFERENCES_PAGE_ID);
+        assertExtensionRegistered(registry, "org.eclipse.debug.ui.detailPaneFactories", "id", "mirur.plugin.detailpane.ArrayDetailPaneFactory");
+    }
+
+    @Test
+    public void opensStatisticsViewInWorkbench() throws Exception {
+        IWorkbenchWindow window = activeWorkbenchWindow();
+        IWorkbenchPage page = window.getActivePage();
+
+        assertNotNull("Workbench window should have an active page", page);
+
+        IViewPart view = page.showView(STATISTICS_VIEW_ID);
+        try {
+            assertTrue("Statistics view should instantiate from the registered extension", STATISTICS_VIEW_CLASS.equals(view.getClass().getName()));
+        } finally {
+            page.hideView(view);
+        }
+    }
+
+    private static IWorkbenchWindow activeWorkbenchWindow() {
+        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        if (window != null) {
+            return window;
+        }
+
+        IWorkbenchWindow[] windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+        assertTrue("UI harness should open at least one workbench window", windows.length > 0);
+        return windows[0];
+    }
+
+    private static void assertExtensionRegistered(IExtensionRegistry registry, String extensionPointId, String attributeName, String attributeValue) {
+        for (IConfigurationElement element : registry.getConfigurationElementsFor(extensionPointId)) {
+            if (PLUGIN_ID.equals(element.getContributor().getName()) && attributeValue.equals(element.getAttribute(attributeName))) {
+                return;
+            }
+        }
+
+        throw new AssertionError("Expected extension " + extensionPointId + " with " + attributeName + "=" + attributeValue);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>mirur-jogl-osx</module>
         <module>mirur-agent</module>
         <module>mirur-ui</module>
+        <module>mirur-ui.tests</module>
         <module>mirur-feature</module>
         <module>mirur-repository</module>
     </modules>

--- a/releng/target-platform/mirur.target
+++ b/releng/target-platform/mirur.target
@@ -9,6 +9,7 @@
             <unit id="org.eclipse.debug.ui" version="0.0.0"/>
             <unit id="org.eclipse.jdt.debug" version="0.0.0"/>
             <unit id="org.eclipse.jface.text" version="0.0.0"/>
+            <unit id="org.junit" version="0.0.0"/>
             <repository location="https://download.eclipse.org/releases/2026-03/202603111000/"/>
         </location>
     </locations>


### PR DESCRIPTION
### Motivation
- Provide automated, repeatable smoke coverage that verifies the Mirur UI bundle installs and exposes expected workbench extensions and a lightweight view under an Eclipse workbench runtime. 
- Make a path for headless CI to exercise OSGi/plug-in wiring and a minimal UI smoke harness while keeping `test-workspace/` as manual/sample content.

### Description
- Add a new `mirur-ui.tests` Tycho `eclipse-test-plugin` module with a `pom.xml` that configures `tycho-surefire-plugin` to use the UI harness (`useUIHarness`, `useUIThread`, `application` and `appArgLine`) and create an isolated workspace under `target/workspaces/smoke`.
- Add test bundle metadata (`mirur-ui.tests/META-INF/MANIFEST.MF`) and `build.properties`, and register the module in the parent `pom.xml` so it participates in the reactor.
- Implement `PluginSmokeTest` which starts the `mirur.mirur-ui` bundle in the test runtime, asserts extension registrations (views, preference page, debug detail pane), and instantiates the Statistics view via workbench APIs using stable IDs/strings instead of non-API internals.
- Update the checked-in target definition `releng/target-platform/mirur.target` to include `org.junit` and document how to run the smoke tests in `docs/development.md` with CI guidance (`xvfb-run` on Linux agents).

### Testing
- Ran `mvn -B -Dtycho.localArtifacts=ignore -pl releng/target-platform install`, which succeeded and installed the target artifact to the local repository.
- Attempted `mvn -B -Dtycho.localArtifacts=ignore -pl mirur-agent,mirur-ui,mirur-ui.tests -am verify` with `-Dproguard.skip=true`; the Tycho runtime started but the UI tests failed to launch in this container because SWT could not load GTK native libraries (`libgtk-3.so.0` / `libgtk-4.so.1`), so the UI tests could not run locally here.
- Verified the reactor build completes when skipping tests with `-DskipTests` (used `mvn ... -Dproguard.skip=true -DskipTests -pl mirur-agent,mirur-ui,mirur-ui.tests -am verify`), which succeeded; documentation recommends running the UI smoke tests on CI agents with a display server or under `xvfb-run` so SWT can load native GTK libraries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a724429088322a206af1f9b066a3a)