### PR TITLE
Upgrade Gradle and IntelliJ platform, add Java toolchains and local IDE support, make action class open

### DIFF
--- a/.github/workflows/intellij-plugin.yml
+++ b/.github/workflows/intellij-plugin.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.14.3'
+          gradle-version: 9.0.0
 
       - name: Build IntelliJ plugin
         working-directory: mirur-intellij-plugin
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.14.3'
+          gradle-version: 9.0.0
 
       - name: Run IntelliJ plugin verifier
         working-directory: mirur-intellij-plugin

--- a/mirur-intellij-plugin/build.gradle.kts
+++ b/mirur-intellij-plugin/build.gradle.kts
@@ -1,22 +1,39 @@
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.1.21"
-    id("org.jetbrains.intellij.platform") version "2.7.2"
+    id("org.jetbrains.intellij.platform") version "2.16.0"
 }
 
 group = "io.mirur"
 version = "0.1.0-SNAPSHOT"
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
 repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
+        marketplace()
     }
 }
 
+val localIdePath = providers.environmentVariable("MIRUR_INTELLIJ_IDE_PATH").orNull
+
 dependencies {
     intellijPlatform {
-        intellijIdeaCommunity("2024.2.4")
+        if (!localIdePath.isNullOrBlank()) {
+            local(localIdePath)
+        } else {
+            intellijIdeaCommunity("2024.2.4")
+        }
         bundledPlugin("com.intellij.java")
         pluginVerifier()
         // no IntelliJ test framework dependency yet; smokeTest covers plugin descriptor wiring
@@ -27,18 +44,10 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = "242"
+            untilBuild = "242.*"
         }
     }
 }
-
-tasks {
-    patchPluginXml {
-        sinceBuild.set("242")
-        untilBuild.set("242.*")
-    }
-}
-
-
 
 tasks.register("smokeTest") {
     group = "verification"
@@ -55,7 +64,6 @@ tasks.register("smokeTest") {
         require("MirurSettingsService" in text) { "Settings service registration missing" }
     }
 }
-
 
 tasks.test {
     enabled = false

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/SubmitToMirurAction.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/SubmitToMirurAction.kt
@@ -6,8 +6,8 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAware
 
-class SubmitToMirurAction : AnAction(), DumbAware {
-    override fun actionPerformed(e: AnActionEvent) {
+open class SubmitToMirurAction : AnAction(), DumbAware {
+    override open fun actionPerformed(e: AnActionEvent) {
         NotificationGroupManager.getInstance()
             .getNotificationGroup("Mirur")
             .createNotification(


### PR DESCRIPTION
### Motivation
- Ensure the plugin builds against newer toolchains and the latest IntelliJ Gradle plugin for compatibility with Java 21 and current IntelliJ versions.
- Allow local IDE testing by wiring an environment-driven local IDE path to speed up verification during development.
- Make the action class extensible for testing or downstream customization by opening the class and its handler.

### Description
- Bumped Gradle used in CI from `8.14.3` to `9.0.0` in the GitHub Actions workflow for both build and verifier jobs.
- Upgraded the IntelliJ Gradle plugin from `2.7.2` to `2.16.0` and set the `ideaVersion` `sinceBuild`/`untilBuild` to `"242"` / `"242.*"` in `build.gradle.kts`.
- Added Java and Kotlin toolchains targeting Java 21 via the Gradle `toolchain` and `jvmToolchain` settings.
- Added `marketplace()` repository and conditional dependency resolution that uses the `MIRUR_INTELLIJ_IDE_PATH` environment variable when present, otherwise falls back to `intellijIdeaCommunity("2024.2.4")`.
- Removed the explicit `patchPluginXml` task configuration in favor of `intellijPlatform` plugin configuration and left `smokeTest` and `buildPlugin` wiring intact.
- Made `SubmitToMirurAction` an `open` class and marked `actionPerformed` as `open` to allow subclassing and overriding.

### Testing
- CI runs `gradle --no-daemon clean smokeTest buildPlugin` in the build job and `gradle --no-daemon verifyPlugin` in the verifier job with the updated Gradle, and these verification tasks completed successfully.
- The repository `test` task remains disabled via `tasks.test { enabled = false }` so no unit tests were executed.
- The custom `smokeTest` task which validates `META-INF/plugin.xml` was executed and passed in the build pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fbb407bf4832294141d61fa6bf1e8)