### PR TITLE
Gate Submit to Mirur action on debugger session and eligible value type

### DIFF
--- a/mirur-intellij-plugin/build.gradle.kts
+++ b/mirur-intellij-plugin/build.gradle.kts
@@ -60,6 +60,7 @@ tasks.register("smokeTest") {
         val text = pluginXml.readText()
         require("<id>io.mirur</id>" in text) { "plugin id missing" }
         require("Mirur.SubmitSelection" in text) { "Submit action missing" }
+        require("text=\"Submit to Mirur\"" in text) { "Submit action label missing or changed" }
         require("MirurToolWindowFactory" in text) { "Tool window factory registration missing" }
         require("MirurSettingsService" in text) { "Settings service registration missing" }
     }

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurValueEligibility.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurValueEligibility.kt
@@ -1,0 +1,28 @@
+package io.mirur.intellij
+
+/**
+ * Lightweight, string-based type classifier for v0 debugger support.
+ */
+object MirurValueEligibility {
+    private val primitiveNumericArrayRegex = Regex("""^(?:byte|short|int|long|float|double)\s*\[\s*]$""")
+    private val boxedNumericArrayRegex = Regex(
+        """^(?:java\.lang\.)?(?:Byte|Short|Integer|Long|Float|Double)\s*\[\s*]$"""
+    )
+
+    fun isEligible(typeText: String?): Boolean {
+        if (typeText.isNullOrBlank()) return false
+        val normalized = typeText.replace("? extends ", "").trim()
+        return isPrimitiveNumericArray(normalized)
+            || isBoxedNumericArray(normalized)
+            || isListOfNumber(normalized)
+    }
+
+    fun isPrimitiveNumericArray(typeText: String): Boolean = primitiveNumericArrayRegex.matches(typeText)
+
+    fun isBoxedNumericArray(typeText: String): Boolean = boxedNumericArrayRegex.matches(typeText)
+
+    fun isListOfNumber(typeText: String): Boolean {
+        val collapsed = typeText.replace("\\s+".toRegex(), "")
+        return collapsed == "java.util.List<java.lang.Number>" || collapsed == "List<Number>"
+    }
+}

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/XDebuggerSubmitToMirurAction.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/XDebuggerSubmitToMirurAction.kt
@@ -3,6 +3,7 @@ package io.mirur.intellij
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformCoreDataKeys
 import com.intellij.openapi.project.DumbAware
 import com.intellij.xdebugger.XDebuggerManager
 
@@ -12,11 +13,26 @@ import com.intellij.xdebugger.XDebuggerManager
  * Attempts to submit current editor selection/expression in the active debug session.
  */
 class XDebuggerSubmitToMirurAction : SubmitToMirurAction(), DumbAware {
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val session = project?.let { XDebuggerManager.getInstance(it).currentSession }
+        val selectedValue = selectedDebuggerValue(e)
+        e.presentation.isEnabledAndVisible = session != null
+            && MirurValueEligibility.isEligible(extractTypeText(selectedValue))
+    }
+
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val session = XDebuggerManager.getInstance(project).currentSession
         if (session == null) {
             notify(project, "No active debug session.")
+            return
+        }
+
+        val selectedValue = selectedDebuggerValue(e)
+        val selectedType = extractTypeText(selectedValue)
+        if (!MirurValueEligibility.isEligible(selectedType)) {
+            notify(project, "Selected debugger value is not yet supported in v0.")
             return
         }
 
@@ -48,5 +64,31 @@ class XDebuggerSubmitToMirurAction : SubmitToMirurAction(), DumbAware {
             .getNotificationGroup("Mirur")
             .createNotification("Mirur", message, NotificationType.INFORMATION)
             .notify(project)
+    }
+
+    private fun selectedDebuggerValue(e: AnActionEvent): Any? = e.getData(PlatformCoreDataKeys.SELECTED_ITEM)
+
+    private fun extractTypeText(selectedValue: Any?): String? {
+        if (selectedValue == null) return null
+        return readStringMember(selectedValue, "type")
+            ?: readStringMember(selectedValue, "typeName")
+            ?: readStringMember(selectedValue, "declaredType")
+    }
+
+    private fun readStringMember(target: Any, memberName: String): String? {
+        val kClass = target::class.java
+        val getterName = "get" + memberName.replaceFirstChar { it.uppercaseChar() }
+        runCatching {
+            val value = kClass.methods
+                .firstOrNull { it.parameterCount == 0 && it.name == getterName }
+                ?.invoke(target)
+            value as? String
+        }.getOrNull()?.let { return it }
+
+        return runCatching {
+            val field = kClass.declaredFields.firstOrNull { it.name == memberName } ?: return null
+            field.isAccessible = true
+            field.get(target) as? String
+        }.getOrNull()
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the debugger "Submit to Mirur" action is only visible/usable when it can meaningfully operate: an active debug session exists and the selected debugger value is a supported v0 shape (primitive numeric arrays, boxed numeric arrays, or `List<Number>`).
- Avoid coupling to debugger internals while keeping `actionPerformed` defensive so unsupported cases are rejected at runtime.

### Description
- Added a small classifier utility `MirurValueEligibility` to recognize supported types by string form (primitive numeric arrays, boxed numeric arrays, and `List<Number`) in `mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurValueEligibility.kt`.
- Implemented `update(e: AnActionEvent)` in `XDebuggerSubmitToMirurAction` to set `e.presentation.isEnabledAndVisible` only when an active debug session exists and the selected debugger value type is eligible.
- Kept `actionPerformed` defensive by re-checking session presence and value eligibility before submitting, and added reflective helpers using `PlatformCoreDataKeys.SELECTED_ITEM` to extract likely `type`/`typeName`/`declaredType` members without hard dependency on debugger internals.
- Expanded the plugin descriptor smoke checks in `build.gradle.kts` to assert the action label text `Submit to Mirur` as part of the `smokeTest` task.

### Testing
- Attempted to run the plugin smoke test with `./gradlew -p mirur-intellij-plugin smokeTest`, but execution failed because there is no Gradle wrapper script in the repository, so the task was not executed.
- No other automated tests were run in this change; the `smokeTest` task was added/updated and will validate the `plugin.xml` when run with a local Gradle installation or a wrapper present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e474567c8322b8f0533414970ebe)