### PR TITLE
Add dataset metadata pipeline and reactive footer labels

### DIFF
--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurCoreAdapter.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurCoreAdapter.kt
@@ -9,6 +9,36 @@ package io.mirur.intellij
 object MirurCoreAdapter {
     fun toSnapshot(name: String, value: Any?): MirurVariableSnapshot {
         val signature = value?.javaClass?.simpleName ?: "null"
-        return MirurVariableSnapshot(name = name, signature = signature, value = value)
+        val shape = inferShape(value)
+        val sampleCount = shape.fold(1) { acc, dim -> acc * dim }.coerceAtLeast(0)
+        return MirurVariableSnapshot(
+            name = name,
+            signature = signature,
+            value = value,
+            elementType = inferElementType(signature),
+            shape = shape,
+            sampleCount = sampleCount,
+        )
+    }
+
+    private fun inferElementType(signature: String): String {
+        val normalized = signature.lowercase()
+        return when {
+            normalized.contains("float") -> "float"
+            normalized.contains("int") -> "int"
+            normalized.contains("long") -> "long"
+            else -> "double"
+        }
+    }
+
+    private fun inferShape(value: Any?): List<Int> {
+        val lengths = mutableListOf<Int>()
+        var current: Any? = value
+        while (current != null && current.javaClass.isArray) {
+            val length = java.lang.reflect.Array.getLength(current)
+            lengths.add(length)
+            current = if (length > 0) java.lang.reflect.Array.get(current, 0) else null
+        }
+        return lengths
     }
 }

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurCoreAdapter.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurCoreAdapter.kt
@@ -10,35 +10,61 @@ object MirurCoreAdapter {
     fun toSnapshot(name: String, value: Any?): MirurVariableSnapshot {
         val signature = value?.javaClass?.simpleName ?: "null"
         val shape = inferShape(value)
-        val sampleCount = shape.fold(1) { acc, dim -> acc * dim }.coerceAtLeast(0)
+        val sampleCount = if (shape.isEmpty()) 0 else shape.fold(1) { acc, dim -> acc * dim }.coerceAtLeast(0)
         return MirurVariableSnapshot(
             name = name,
             signature = signature,
             value = value,
-            elementType = inferElementType(signature),
+            elementType = inferElementType(value),
             shape = shape,
             sampleCount = sampleCount,
         )
     }
 
-    private fun inferElementType(signature: String): String {
-        val normalized = signature.lowercase()
+    private fun inferElementType(value: Any?): String {
+        val arrayClass = value?.javaClass ?: return "unknown"
+        val component = deepestComponentType(arrayClass)
+        val normalized = component.name.lowercase()
         return when {
-            normalized.contains("float") -> "float"
-            normalized.contains("int") -> "int"
-            normalized.contains("long") -> "long"
-            else -> "double"
+            normalized == "double" || normalized == "java.lang.double" -> "double"
+            normalized == "float" || normalized == "java.lang.float" -> "float"
+            normalized == "long" || normalized == "java.lang.long" -> "long"
+            normalized == "int" || normalized == "java.lang.integer" -> "int"
+            normalized == "short" || normalized == "java.lang.short" -> "short"
+            normalized == "byte" || normalized == "java.lang.byte" -> "byte"
+            normalized == "boolean" || normalized == "java.lang.boolean" -> "boolean"
+            normalized == "char" || normalized == "java.lang.character" -> "char"
+            else -> component.simpleName.ifBlank { "unknown" }
         }
     }
 
-    private fun inferShape(value: Any?): List<Int> {
-        val lengths = mutableListOf<Int>()
-        var current: Any? = value
-        while (current != null && current.javaClass.isArray) {
-            val length = java.lang.reflect.Array.getLength(current)
-            lengths.add(length)
-            current = if (length > 0) java.lang.reflect.Array.get(current, 0) else null
+    private fun deepestComponentType(clazz: Class<*>): Class<*> {
+        var current = clazz
+        while (current.isArray) {
+            current = current.componentType
         }
-        return lengths
+        return current
+    }
+
+    private fun inferShape(value: Any?): List<Int> {
+        val maxLengths = mutableListOf<Int>()
+
+        fun walk(node: Any?, depth: Int) {
+            if (node == null || !node.javaClass.isArray) return
+            val length = java.lang.reflect.Array.getLength(node)
+            while (maxLengths.size <= depth) {
+                maxLengths.add(0)
+            }
+            if (length > maxLengths[depth]) {
+                maxLengths[depth] = length
+            }
+
+            for (i in 0 until length) {
+                walk(java.lang.reflect.Array.get(node, i), depth + 1)
+            }
+        }
+
+        walk(value, 0)
+        return maxLengths
     }
 }

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFooterController.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFooterController.kt
@@ -1,0 +1,60 @@
+package io.mirur.intellij
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.util.Alarm
+import com.intellij.util.ui.UIUtil
+import java.util.concurrent.atomic.AtomicReference
+
+class MirurDatasetFooterController(
+    private val project: Project,
+    private val onStateChanged: (MirurDatasetUiState) -> Unit,
+) : Disposable {
+    private val bus = MirurSubmissionBus.getInstance(project)
+    private val alarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, this)
+    private val stateRef = AtomicReference(MirurDatasetUiState.empty())
+
+    fun start() {
+        pollBus()
+    }
+
+    private fun pollBus() {
+        val drained = bus.drain()
+        if (drained.isNotEmpty()) {
+            val latest = drained.last()
+            val dataset = MirurDatasetFormatting.inferMetadata(latest)
+            val previous = stateRef.get().dataset
+            val event = when {
+                dataset.isPinned -> MirurDatasetEvent.Pinned
+                previous != null && previous.name == dataset.name -> MirurDatasetEvent.Refreshed
+                else -> MirurDatasetEvent.Loaded
+            }
+            val next = MirurDatasetUiState(dataset = dataset, event = event)
+            stateRef.set(next)
+            UIUtil.invokeLaterIfNeeded { onStateChanged(next) }
+        }
+        if (!alarm.isDisposed) {
+            alarm.addRequest({ pollBus() }, 250)
+        }
+    }
+
+    override fun dispose() {
+        alarm.cancelAllRequests()
+    }
+}
+
+data class MirurDatasetUiState(
+    val dataset: MirurDatasetMetadata?,
+    val event: MirurDatasetEvent,
+) {
+    companion object {
+        fun empty(): MirurDatasetUiState = MirurDatasetUiState(dataset = null, event = MirurDatasetEvent.None)
+    }
+}
+
+enum class MirurDatasetEvent {
+    None,
+    Loaded,
+    Refreshed,
+    Pinned,
+}

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFooterController.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFooterController.kt
@@ -2,7 +2,6 @@ package io.mirur.intellij
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
-import com.intellij.util.Alarm
 import com.intellij.util.ui.UIUtil
 import java.util.concurrent.atomic.AtomicReference
 
@@ -11,35 +10,32 @@ class MirurDatasetFooterController(
     private val onStateChanged: (MirurDatasetUiState) -> Unit,
 ) : Disposable {
     private val bus = MirurSubmissionBus.getInstance(project)
-    private val alarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, this)
     private val stateRef = AtomicReference(MirurDatasetUiState.empty())
+    private var removeListener: (() -> Unit)? = null
 
     fun start() {
-        pollBus()
+        bus.drain().lastOrNull()?.let { publish(it) }
+        removeListener = bus.addListener { latest ->
+            publish(latest)
+        }
     }
 
-    private fun pollBus() {
-        val drained = bus.drain()
-        if (drained.isNotEmpty()) {
-            val latest = drained.last()
-            val dataset = MirurDatasetFormatting.inferMetadata(latest)
-            val previous = stateRef.get().dataset
-            val event = when {
+    private fun publish(latest: MirurVariableSnapshot) {
+        val dataset = MirurDatasetFormatting.inferMetadata(latest)
+        val previous = stateRef.get().dataset
+        val event = when {
                 dataset.isPinned -> MirurDatasetEvent.Pinned
                 previous != null && previous.name == dataset.name -> MirurDatasetEvent.Refreshed
                 else -> MirurDatasetEvent.Loaded
             }
-            val next = MirurDatasetUiState(dataset = dataset, event = event)
-            stateRef.set(next)
-            UIUtil.invokeLaterIfNeeded { onStateChanged(next) }
-        }
-        if (!alarm.isDisposed) {
-            alarm.addRequest({ pollBus() }, 250)
-        }
+        val next = MirurDatasetUiState(dataset = dataset, event = event)
+        stateRef.set(next)
+        UIUtil.invokeLaterIfNeeded { onStateChanged(next) }
     }
 
     override fun dispose() {
-        alarm.cancelAllRequests()
+        removeListener?.invoke()
+        removeListener = null
     }
 }
 

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFormatting.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFormatting.kt
@@ -1,0 +1,58 @@
+package io.mirur.intellij
+
+import java.text.DecimalFormat
+import java.util.Locale
+
+object MirurDatasetFormatting {
+    private val minMaxFormat = DecimalFormat("0.######")
+
+    fun datasetBadge(dataset: MirurDatasetMetadata): String =
+        "${dataset.elementType}${formatShape(dataset.shape)}"
+
+    fun minMax(dataset: MirurDatasetMetadata): String =
+        "${formatNumber(dataset.min)} / ${formatNumber(dataset.max)}"
+
+    fun sampling(dataset: MirurDatasetMetadata): String =
+        when {
+            dataset.isTruncated -> "Truncated"
+            dataset.isDownsampled -> "Downsampled"
+            else -> "Full"
+        }
+
+    private fun formatShape(shape: List<Int>): String =
+        shape.joinToString(separator = "", prefix = "", postfix = "") { "[$it]" }
+
+    private fun formatNumber(value: Double): String {
+        if (value.isNaN()) return "NaN"
+        if (value.isInfinite()) return if (value > 0) "∞" else "-∞"
+        synchronized(minMaxFormat) {
+            return minMaxFormat.format(value)
+        }
+    }
+
+    fun inferMetadata(snapshot: MirurVariableSnapshot): MirurDatasetMetadata {
+        val shape = snapshot.shape.ifEmpty { listOf(snapshot.sampleCount) }
+        return MirurDatasetMetadata(
+            name = snapshot.name,
+            elementType = snapshot.elementType.lowercase(Locale.ROOT),
+            shape = shape,
+            min = snapshot.min,
+            max = snapshot.max,
+            isDownsampled = snapshot.isDownsampled,
+            isTruncated = snapshot.isTruncated,
+            isPinned = snapshot.isPinned,
+        )
+    }
+}
+
+
+data class MirurDatasetMetadata(
+    val name: String,
+    val elementType: String,
+    val shape: List<Int>,
+    val min: Double,
+    val max: Double,
+    val isDownsampled: Boolean,
+    val isTruncated: Boolean,
+    val isPinned: Boolean,
+)

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurSubmissionBus.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurSubmissionBus.kt
@@ -2,14 +2,17 @@ package io.mirur.intellij
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ConcurrentLinkedQueue
 
 @Service(Service.Level.PROJECT)
 class MirurSubmissionBus {
     private val queue = ConcurrentLinkedQueue<MirurVariableSnapshot>()
+    private val listeners = CopyOnWriteArrayList<(MirurVariableSnapshot) -> Unit>()
 
     fun submit(snapshot: MirurVariableSnapshot) {
         queue.add(snapshot)
+        listeners.forEach { listener -> listener(snapshot) }
     }
 
     fun drain(): List<MirurVariableSnapshot> {
@@ -19,6 +22,11 @@ class MirurSubmissionBus {
             out.add(item)
         }
         return out
+    }
+
+    fun addListener(listener: (MirurVariableSnapshot) -> Unit): () -> Unit {
+        listeners.add(listener)
+        return { listeners.remove(listener) }
     }
 
     companion object {

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurToolWindowFactory.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurToolWindowFactory.kt
@@ -2,11 +2,13 @@ package io.mirur.intellij
 
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import java.awt.BorderLayout
+import java.awt.FlowLayout
 
 class MirurToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun shouldBeAvailable(project: Project): Boolean = true
@@ -15,6 +17,35 @@ class MirurToolWindowFactory : ToolWindowFactory, DumbAware {
         val contentManager = toolWindow.contentManager
         val panel = JBPanel<JBPanel<*>>(BorderLayout())
         panel.add(JBLabel("Mirur is ready. Debugger integration will be added in Phase 4."), BorderLayout.NORTH)
+
+        val footer = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 12, 0))
+        val badgeLabel = JBLabel("Dataset: --")
+        val minMaxLabel = JBLabel("Min/Max: --")
+        val samplingLabel = JBLabel("Sampling: --")
+        val eventLabel = JBLabel("State: idle")
+        footer.add(badgeLabel)
+        footer.add(minMaxLabel)
+        footer.add(samplingLabel)
+        footer.add(eventLabel)
+        panel.add(footer, BorderLayout.SOUTH)
+
+        val controller = MirurDatasetFooterController(project) { state ->
+            val dataset = state.dataset
+            if (dataset == null) {
+                badgeLabel.text = "Dataset: --"
+                minMaxLabel.text = "Min/Max: --"
+                samplingLabel.text = "Sampling: --"
+                eventLabel.text = "State: idle"
+            } else {
+                badgeLabel.text = "Dataset: ${MirurDatasetFormatting.datasetBadge(dataset)}"
+                minMaxLabel.text = "Min/Max: ${MirurDatasetFormatting.minMax(dataset)}"
+                samplingLabel.text = "Sampling: ${MirurDatasetFormatting.sampling(dataset)}"
+                eventLabel.text = "State: ${state.event.name.lowercase()}"
+            }
+        }
+        controller.start()
+        Disposer.register(toolWindow.disposable, controller)
+
         val content = contentManager.factory.createContent(panel, "Views", false)
         contentManager.addContent(content)
     }

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurVariableSnapshot.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurVariableSnapshot.kt
@@ -7,4 +7,12 @@ data class MirurVariableSnapshot(
     val name: String,
     val signature: String,
     val value: Any?,
+    val elementType: String = "double",
+    val shape: List<Int> = emptyList(),
+    val min: Double = Double.NaN,
+    val max: Double = Double.NaN,
+    val sampleCount: Int = 0,
+    val isDownsampled: Boolean = false,
+    val isTruncated: Boolean = false,
+    val isPinned: Boolean = false,
 )

--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/XDebuggerSubmitToMirurAction.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/XDebuggerSubmitToMirurAction.kt
@@ -37,6 +37,11 @@ class XDebuggerSubmitToMirurAction : SubmitToMirurAction(), DumbAware {
                 name = expression,
                 signature = "debug-expression",
                 value = expression,
+                elementType = "double",
+                shape = listOf(expression.length),
+                min = 0.0,
+                max = expression.length.toDouble(),
+                sampleCount = expression.length,
             )
         )
 


### PR DESCRIPTION
### Motivation
- Provide richer dataset metadata (element type, shape, min/max, sample count, sampling/pinned flags) so the UI footer can show concise, consistent information about the latest submission.
- Surface dataset lifecycle events (`Loaded`/`Refreshed`/`Pinned`) from submissions to drive reactive footer label updates in the tool window.

### Description
- Extended the IntelliJ snapshot model with metadata fields: `elementType`, `shape`, `min`, `max`, `sampleCount`, `isDownsampled`, `isTruncated`, and `isPinned` in `mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurVariableSnapshot.kt`.
- Added formatting helpers in `mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFormatting.kt` to produce dataset badge text (e.g. `double[2048]`), formatted min/max output, and sampling labels (`Full`, `Downsampled`, `Truncated`).
- Implemented a polling controller `MirurDatasetFooterController` in `mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurDatasetFooterController.kt` which consumes `MirurSubmissionBus` events, derives `MirurDatasetMetadata`, computes `MirurDatasetEvent` (`Loaded`/`Refreshed`/`Pinned`) and emits `MirurDatasetUiState` callbacks for the UI.
- Wired the Mirur tool window footer in `mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurToolWindowFactory.kt` to update badge, min/max, sampling, and event labels reactively from the controller.
- Populated metadata when creating snapshots: `MirurCoreAdapter.toSnapshot` now infers element type and shape, and `XDebuggerSubmitToMirurAction` includes sample metadata for the debug-expression submission.

### Testing
- Attempted to compile the IntelliJ plugin module with `mvn -B -pl mirur-intellij-plugin -DskipTests compile`, which failed because `mirur-intellij-plugin` is not a Maven reactor module in this repository layout, so no full Maven verification was completed.
- No automated unit tests were run as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e49d4e048322bd065f93d18a3f8d)