### PR TITLE
Add MirurUiState and state-specific tool window rendering

### DIFF
--- a/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurToolWindowFactory.kt
+++ b/mirur-intellij-plugin/src/main/kotlin/io/mirur/intellij/MirurToolWindowFactory.kt
@@ -1,21 +1,174 @@
 package io.mirur.intellij
 
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
+import com.intellij.ui.components.JBTextArea
+import com.intellij.util.Alarm
+import com.intellij.xdebugger.XDebugSessionListener
+import com.intellij.xdebugger.XDebuggerManager
 import java.awt.BorderLayout
+import java.awt.CardLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+
+sealed interface MirurUiState {
+    data object Empty : MirurUiState
+
+    data class Unsupported(val reason: String, val link: String) : MirurUiState
+
+    data object Disconnected : MirurUiState
+
+    data class Ready(val data: MirurVariableSnapshot) : MirurUiState
+}
 
 class MirurToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun shouldBeAvailable(project: Project): Boolean = true
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val contentManager = toolWindow.contentManager
-        val panel = JBPanel<JBPanel<*>>(BorderLayout())
-        panel.add(JBLabel("Mirur is ready. Debugger integration will be added in Phase 4."), BorderLayout.NORTH)
+        val panel = MirurToolWindowPanel(project)
         val content = contentManager.factory.createContent(panel, "Views", false)
+        content.setDisposer(panel)
         contentManager.addContent(content)
+    }
+}
+
+private class MirurToolWindowPanel(private val project: Project) : JBPanel<JBPanel<*>>(BorderLayout()), Disposable {
+    private val cardLayout = CardLayout()
+    private val cards = JBPanel<JBPanel<*>>(cardLayout)
+    private val refreshButton = JButton("Refresh")
+    private val emptyCard = createMessageCard("Select a numeric array in Debug Variables, then choose ‘Visualize with Mirur’.")
+    private val disconnectedCard = createMessageCard("Debug session ended. Refresh unavailable.")
+    private val unsupportedReason = JBLabel()
+    private val supportedTypesLink = ActionLink("Supported types") {
+        NotificationGroupManager.getInstance().getNotificationGroup("Mirur")
+            .createNotification("Mirur", "Supported types docs: $supportedTypesUrl", NotificationType.INFORMATION)
+            .notify(project)
+    }
+    private val unsupportedCard = createUnsupportedCard()
+    private val readyData = JBTextArea()
+    private val readyCard = createReadyCard()
+    private val alarm = Alarm(Alarm.ThreadToUse.SWING_THREAD, this)
+    private var supportedTypesUrl: String = "https://mirur.io/docs/intellij/supported-types"
+    private var currentState: MirurUiState = MirurUiState.Empty
+
+    init {
+        add(buildToolbar(), BorderLayout.NORTH)
+        add(cards, BorderLayout.CENTER)
+        cards.add(emptyCard, MirurUiState.Empty::class.java.simpleName)
+        cards.add(disconnectedCard, MirurUiState.Disconnected::class.java.simpleName)
+        cards.add(unsupportedCard, MirurUiState.Unsupported::class.java.simpleName)
+        cards.add(readyCard, MirurUiState.Ready::class.java.simpleName)
+
+        wireDebugSessionEvents()
+        scheduleQueuePoll()
+        render(MirurUiState.Empty)
+    }
+
+    private fun buildToolbar(): JComponent {
+        val toolbar = JBPanel<JBPanel<*>>(BorderLayout())
+        refreshButton.addActionListener {
+            scheduleQueuePoll()
+        }
+        toolbar.add(refreshButton, BorderLayout.WEST)
+        return toolbar
+    }
+
+    private fun wireDebugSessionEvents() {
+        XDebuggerManager.getInstance(project).currentSession?.addSessionListener(object : XDebugSessionListener {
+            override fun sessionStopped() {
+                render(MirurUiState.Disconnected)
+            }
+        })
+    }
+
+    private fun scheduleQueuePoll() {
+        alarm.cancelAllRequests()
+        alarm.addRequest({
+            val latest = MirurSubmissionBus.getInstance(project).drain().lastOrNull()
+            if (latest == null) {
+                if (currentState !is MirurUiState.Disconnected) {
+                    render(MirurUiState.Empty)
+                }
+                return@addRequest
+            }
+            if (latest.signature == "debug-expression") {
+                render(MirurUiState.Ready(latest))
+            } else {
+                render(
+                    MirurUiState.Unsupported(
+                        reason = "Type '${latest.signature}' is not currently visualizable.",
+                        link = supportedTypesUrl,
+                    )
+                )
+            }
+        }, 50)
+    }
+
+    private fun render(state: MirurUiState) {
+        currentState = state
+        when (state) {
+            MirurUiState.Empty -> {
+                cardLayout.show(cards, MirurUiState.Empty::class.java.simpleName)
+                refreshButton.isEnabled = true
+            }
+
+            MirurUiState.Disconnected -> {
+                cardLayout.show(cards, MirurUiState.Disconnected::class.java.simpleName)
+                refreshButton.isEnabled = false
+            }
+
+            is MirurUiState.Unsupported -> {
+                unsupportedReason.text = state.reason
+                supportedTypesUrl = state.link
+                cardLayout.show(cards, MirurUiState.Unsupported::class.java.simpleName)
+                refreshButton.isEnabled = true
+            }
+
+            is MirurUiState.Ready -> {
+                readyData.text = "Name: ${state.data.name}\nSignature: ${state.data.signature}\nValue: ${state.data.value}"
+                cardLayout.show(cards, MirurUiState.Ready::class.java.simpleName)
+                refreshButton.isEnabled = true
+            }
+        }
+    }
+
+    private fun createMessageCard(text: String): JComponent {
+        val panel = JBPanel<JBPanel<*>>(BorderLayout())
+        val label = JBLabel(text)
+        panel.add(label, BorderLayout.NORTH)
+        return panel
+    }
+
+    private fun createUnsupportedCard(): JComponent {
+        val panel = JBPanel<JBPanel<*>>(BorderLayout())
+        val content = JBPanel<JBPanel<*>>()
+        content.layout = javax.swing.BoxLayout(content, javax.swing.BoxLayout.Y_AXIS)
+        content.add(unsupportedReason)
+        content.add(supportedTypesLink)
+        panel.add(content, BorderLayout.NORTH)
+        return panel
+    }
+
+    private fun createReadyCard(): JComponent {
+        val panel = JBPanel<JBPanel<*>>(BorderLayout())
+        readyData.isEditable = false
+        readyData.lineWrap = true
+        readyData.wrapStyleWord = true
+        panel.add(readyData, BorderLayout.CENTER)
+        return panel
+    }
+
+    override fun dispose() {
+        Disposer.dispose(alarm)
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous monolithic tool-window text with a small, testable UI state model to match the design doc and simplify future debugger integration. 
- Surface concise, state-specific messaging for Empty, Unsupported, Disconnected, and Ready states so users see the right guidance and actions. 
- Disable refresh when the debug session ends and add an inline Supported types action for unsupported payloads to improve UX and discoverability.

### Description
- Introduce a sealed `MirurUiState` model with variants `Empty`, `Unsupported(reason, link)`, `Disconnected`, and `Ready(data)`.
- Add `MirurToolWindowPanel` and switch the tool window to card-based rendering (`CardLayout`) with separate cards for each state and exact empty-state copy: `Select a numeric array in Debug Variables, then choose ‘Visualize with Mirur’.`.
- Add an inline `Supported types` `ActionLink` and `supportedTypesUrl` that shows the reason + link in the unsupported card, and populate Ready card from `MirurVariableSnapshot` data.
- Wire `XDebuggerManager.currentSession` `sessionStopped` to transition to `Disconnected`, call `content.setDisposer(panel)`, and disable the Refresh button while disconnected; implement `scheduleQueuePoll()` to drain `MirurSubmissionBus` and render `Ready` or `Unsupported` accordingly.

### Testing
- Ran `mvn -pl mirur-intellij-plugin -DskipTests compile` to validate compile, which failed because the module was not found in the invoked Maven reactor in this environment (not merged into reactor build).
- Ran a local Gradle classes task in `mirur-intellij-plugin` (`gradle -q classes`), which failed in this environment with a local tooling error (`25.0.2`), so no successful automated compile/test run completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e4a7ce2c8322a855735c0339f27f)